### PR TITLE
fix: point dependabot to the correct directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,8 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 5
   - package-ecosystem: "gitsubmodule"
-    directory: "contracts/lib"
+    directory: "/"
     allow:
-      - dependency-name: "tnt-core"
+      - dependency-name: "contracts/lib/tnt-core"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Looks like I got the config backwards. I just took this commit out of #16 since it'll probably be a bit before that gets merged in.