### PR TITLE
fix: move Soldeer dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,3 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    allow:
-      - dependency-name: "contracts/lib/tnt-core"
-    schedule:
-      interval: "daily"

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ docs/
 # Generated blueprint files
 blueprint.json
 blueprint.lock
+
+# Soldeer dependencies
+dependencies/

--- a/contracts/src/HelloBlueprint.sol
+++ b/contracts/src/HelloBlueprint.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSE
 pragma solidity >=0.8.13;
 
-import "contracts/lib/tnt-core/src/BlueprintServiceManagerBase.sol";
+import "tnt-core/BlueprintServiceManagerBase.sol";
 
 /**
  * @title HelloBlueprint

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,11 +5,13 @@ out = "contracts/out"
 script = "contracts/script"
 cache_path = "contracts/cache"
 broadcast = "contracts/broadcast"
-libs = ["contracts/lib"]
+libs = ["dependencies"]
 auto_detect_remappings = true
 
 [soldeer]
 recursive_deps = true
+remappings_location = "txt"
+remappings_version = false
 
 [dependencies]
 tnt-core = { version = "0.1.0", git = "https://github.com/tangle-network/tnt-core.git", branch = "main" }

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,1 @@
+tnt-core/=dependencies/tnt-core-0.1.0/src


### PR DESCRIPTION
# Overview
* As far as I can tell, Soldeer will always put the dependencies in the root. I moved `foundry.toml` into `contracts/` to fix that.
* **I had to manually add append /src to the tnt-core remapping**
* Remove submodules from Dependabot
* Fixed import in HelloBlueprint.sol (Soldeer keeps versions in the path)